### PR TITLE
Fix file loading for logo

### DIFF
--- a/src/main/kotlin/com/github/hd/tornadofxsuite/view/MainView.kt
+++ b/src/main/kotlin/com/github/hd/tornadofxsuite/view/MainView.kt
@@ -23,7 +23,7 @@ class MainView : View() {
             prefHeight = 600.0
 
             hbox {
-                imageview("tornado-fx-logo.png")
+                imageview("file:tornado-fx-logo.png")
                 hboxConstraints {
                     marginLeftRight(20.0)
                     marginTopBottom(20.0)


### PR DESCRIPTION
- Looks like loading a file resource requires prepending "file:" in front of the path.